### PR TITLE
Keyple plugin handles Android NFC enabling/disabling (#456)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ To build the plugins, execute the following commands in the **/android folder**,
 To build the example app NFC and OMAPI, first, you need to build and install locally the java component keyple-core, keyple-calypso and keyple-android-plugin (see above)
 
 ```
-./gradlew -b ./example/calypso/nfc/build.gradle assembleDebug 
-./gradlew -b ./example/calypso/omapi/build.gradle assembleDebug
+./gradlew -b ./example/calypso/android/nfc/build.gradle assembleDebug 
+./gradlew -b ./example/calypso/android/omapi/build.gradle assembleDebug
 ```
 
 #### Windows

--- a/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginFactory.kt
+++ b/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginFactory.kt
@@ -11,16 +11,17 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
+import android.app.Activity
 import org.eclipse.keyple.core.service.Plugin
 import org.eclipse.keyple.core.service.PluginFactory
 
-class AndroidNfcPluginFactory : PluginFactory {
+class AndroidNfcPluginFactory(private val activity: Activity) : PluginFactory {
 
     override fun getPluginName(): String {
         return AndroidNfcPlugin.PLUGIN_NAME
     }
 
     override fun getPlugin(): Plugin {
-        return AndroidNfcPluginImpl
+        return AndroidNfcPluginImpl(activity)
     }
 }

--- a/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginImpl.kt
+++ b/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginImpl.kt
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
+import android.app.Activity
 import android.os.Build
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -25,7 +26,9 @@ import timber.log.Timber
  * Will provide 2 version of Android NFC reader based on Android OS version.
  *
  */
-internal object AndroidNfcPluginImpl : AbstractPlugin(AndroidNfcPlugin.PLUGIN_NAME), AndroidNfcPlugin {
+internal class AndroidNfcPluginImpl(private val activity: Activity) :
+    AbstractPlugin(AndroidNfcPlugin.PLUGIN_NAME),
+    AndroidNfcPlugin {
 
     /**
      * For an Android NFC device, the Android NFC Plugin manages only one @[AbstractAndroidNfcReader].
@@ -37,9 +40,9 @@ internal object AndroidNfcPluginImpl : AbstractPlugin(AndroidNfcPlugin.PLUGIN_NA
         Timber.d("InitNativeReader() add the unique instance of AndroidNfcReaderImpl")
         val readers = ConcurrentHashMap<String, Reader>()
         readers[AndroidNfcReader.READER_NAME] = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            AndroidNfcReaderPreNImpl
+            AndroidNfcReaderPreNImpl(activity)
         } else {
-            AndroidNfcReaderPostNImpl
+            AndroidNfcReaderPostNImpl(activity)
         }
         // Nfc android adapter availability is checked in AndroidNfcFragment
         return readers

--- a/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReader.kt
+++ b/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReader.kt
@@ -11,7 +11,6 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
-import android.app.Activity
 import android.content.Intent
 import android.nfc.NfcAdapter
 import org.eclipse.keyple.core.service.Reader
@@ -43,14 +42,9 @@ interface AndroidNfcReader : ObservableReader {
     fun processIntent(intent: Intent)
 
     /**
-     * Declare app to handle NFC Tags while in the foreground
+     * clear context instance
      */
-    fun enableNFCReaderMode(activity: Activity)
-
-    /**
-     * Stop app handling NFC Tags while in the foreground
-     */
-    fun disableNFCReaderMode(activity: Activity)
+    fun clearContext()
 
     /**
      * Configure NFC Reader

--- a/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPostNImpl.kt
+++ b/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPostNImpl.kt
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.plugin.android.nfc
 
 import android.annotation.TargetApi
+import android.app.Activity
 import android.os.Build
 import org.eclipse.keyple.core.plugin.reader.WaitForCardRemovalBlocking
 import timber.log.Timber
@@ -21,7 +22,7 @@ import timber.log.Timber
  *
  * It will used native features of Android NFC API to detect card removal.
  */
-internal object AndroidNfcReaderPostNImpl : AbstractAndroidNfcReader(), WaitForCardRemovalBlocking {
+internal class AndroidNfcReaderPostNImpl(activity: Activity) : AbstractAndroidNfcReader(activity), WaitForCardRemovalBlocking {
 
     private var isWatingForRemoval = false
     private val syncWaitRemoval = Object()

--- a/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPreNImpl.kt
+++ b/android/keyple-plugin/android-nfc/src/main/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPreNImpl.kt
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
+import android.app.Activity
 import org.eclipse.keyple.core.plugin.reader.WaitForCardRemovalNonBlocking
 
 /**
@@ -18,4 +19,4 @@ import org.eclipse.keyple.core.plugin.reader.WaitForCardRemovalNonBlocking
  *
  * It uses a Ping monitoring job to detect card removal
  */
-internal object AndroidNfcReaderPreNImpl : AbstractAndroidNfcReader(), WaitForCardRemovalNonBlocking
+internal class AndroidNfcReaderPreNImpl(activity: Activity) : AbstractAndroidNfcReader(activity), WaitForCardRemovalNonBlocking

--- a/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginFactoryTest.kt
+++ b/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginFactoryTest.kt
@@ -11,21 +11,29 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
+import android.app.Activity
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AndroidNfcPluginFactoryTest {
 
     lateinit var factory: AndroidNfcPluginFactory
 
+    lateinit var activity: Activity
+
     @Before
     fun setUp() {
-        factory = AndroidNfcPluginFactory()
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        factory = AndroidNfcPluginFactory(activity)
     }
 
     @Test
     fun getPluginName() {
-        Assert.assertEquals(AndroidNfcPlugin.PLUGIN_NAME, factory.pluginName)
+        Assert.assertEquals(AndroidNfcReaderPostNImpl(activity).pluginName, factory.pluginName)
     }
 }

--- a/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginImplTest.kt
+++ b/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcPluginImplTest.kt
@@ -11,21 +11,30 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.android.nfc
 
+import android.app.Activity
 import java.io.IOException
 import org.eclipse.keyple.core.service.exception.KeypleReaderException
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AndroidNfcPluginImplTest {
 
-    private val plugin = AndroidNfcPluginImpl
+    private lateinit var plugin: AndroidNfcPluginImpl
+
+    lateinit var activity: Activity
 
     // init before each test
     @Before
     @Throws(IOException::class)
     fun setUp() {
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        plugin = AndroidNfcPluginImpl(activity)
         // get unique instance
         plugin.register()
     }
@@ -60,7 +69,7 @@ class AndroidNfcPluginImplTest {
     @Test
     @Throws(Exception::class)
     fun getName() {
-        Assert.assertEquals(AndroidNfcPluginImpl.name, plugin.name)
+        Assert.assertEquals(AndroidNfcPluginImpl(activity).name, plugin.name)
     }
 
     /*
@@ -70,7 +79,7 @@ class AndroidNfcPluginImplTest {
     @Test
     @Throws(Exception::class)
     fun getNativeReader() {
-        Assert.assertTrue(plugin.getReader(AndroidNfcReader.READER_NAME) is AbstractAndroidNfcReader)
+        Assert.assertTrue(plugin.getReader(AndroidNfcReaderPostNImpl(activity).name) is AndroidNfcReaderPostNImpl)
     }
 
     @Test

--- a/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPostNImplTest.kt
+++ b/android/keyple-plugin/android-nfc/src/test/kotlin/org/eclipse/keyple/plugin/android/nfc/AndroidNfcReaderPostNImplTest.kt
@@ -31,6 +31,7 @@ import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -39,6 +40,8 @@ import org.robolectric.RuntimeEnvironment
 class AndroidNfcReaderPostNImplTest {
 
     private lateinit var reader: AndroidNfcReaderPostNImpl
+
+    private lateinit var activity: Activity
 
     @MockK
     internal lateinit var tag: Tag
@@ -50,8 +53,8 @@ class AndroidNfcReaderPostNImplTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         val app = RuntimeEnvironment.application
-
-        reader = AndroidNfcReaderPostNImpl
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        reader = AndroidNfcReaderPostNImpl(activity)
 
         // We need to mock tag.* because it's called in printTagId() called when channel is closed
         every { tagProxy?.tag } returns tag
@@ -259,6 +262,4 @@ class AndroidNfcReaderPostNImplTest {
     private fun presentMockTag() {
         reader.onTagDiscovered(tag)
     }
-
-    class MyActivity : Activity()
 }

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/plugin/reader/AbstractObservableLocalReader.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/plugin/reader/AbstractObservableLocalReader.java
@@ -113,6 +113,12 @@ public abstract class AbstractObservableLocalReader extends AbstractLocalReader
   /* Service that handles Internal Events and their impact on the current state of the reader */
   protected final ObservableReaderStateService stateService;
 
+  /** Method called when the card detection is started by the Keyple Plugin */
+  protected abstract void onStartDetection();
+
+  /** Method called when the card detection is stopped by the Keyple Plugin */
+  protected abstract void onStopDetection();
+
   /**
    * (protected)<br>
    * Constructor.

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/plugin/reader/ObservableReaderStateService.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/plugin/reader/ObservableReaderStateService.java
@@ -139,6 +139,14 @@ class ObservableReaderStateService {
    * @since 0.9
    */
   protected final synchronized void onEvent(AbstractObservableLocalReader.InternalEvent event) {
+    switch (event) {
+      case START_DETECT:
+        reader.onStartDetection();
+        break;
+      case STOP_DETECT:
+        reader.onStopDetection();
+        break;
+    }
     this.currentState.onEvent(event);
   }
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankObservableLocalReader.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankObservableLocalReader.java
@@ -79,4 +79,16 @@ public class BlankObservableLocalReader extends AbstractObservableLocalReader
   public ReaderEvent processCardInsertedTest() {
     return processCardInserted();
   }
+
+  public void stopWaitForCard() {}
+
+  @Override
+  protected void onStartDetection() {
+    // Do nothing
+  }
+
+  @Override
+  protected void onStopDetection() {
+    // Do nothing
+  }
 }

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankPresenceWaitForCardBlockingThreadedReader.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankPresenceWaitForCardBlockingThreadedReader.java
@@ -104,4 +104,14 @@ public class BlankPresenceWaitForCardBlockingThreadedReader extends AbstractObse
     detectCount++;
     return detectCount <= mockDetect;
   }
+
+  @Override
+  protected void onStartDetection() {
+    // Do nothing
+  }
+
+  @Override
+  protected void onStopDetection() {
+    // Do nothing
+  }
 }

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankWaitForCardInsertionBlockingThreadedReader.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/plugin/reader/BlankWaitForCardInsertionBlockingThreadedReader.java
@@ -123,4 +123,14 @@ public class BlankWaitForCardInsertionBlockingThreadedReader extends AbstractObs
 
   @Override
   public void stopWaitForCard() {}
+
+  @Override
+  protected void onStartDetection() {
+    // Do nothing
+  }
+
+  @Override
+  protected void onStopDetection() {
+    // Do nothing
+  }
 }

--- a/java/component/keyple-plugin/pcsc/src/main/java/org/eclipse/keyple/plugin/pcsc/AbstractPcscReader.java
+++ b/java/component/keyple-plugin/pcsc/src/main/java/org/eclipse/keyple/plugin/pcsc/AbstractPcscReader.java
@@ -94,6 +94,14 @@ abstract class AbstractPcscReader extends AbstractObservableLocalReader
     logger.debug("[{}] constructor => using terminal ", terminal);
   }
 
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  @Override
+  protected void onStartDetection() {}
+
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  @Override
+  protected void onStopDetection() {}
+
   /**
    * {@inheritDoc}
    *

--- a/java/component/keyple-plugin/stub/src/main/java/org/eclipse/keyple/plugin/stub/StubReaderImpl.java
+++ b/java/component/keyple-plugin/stub/src/main/java/org/eclipse/keyple/plugin/stub/StubReaderImpl.java
@@ -63,6 +63,14 @@ class StubReaderImpl extends AbstractObservableLocalReader
     this.isContactless = isContactless;
   }
 
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  @Override
+  protected void onStartDetection() {}
+
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  @Override
+  protected void onStopDetection() {}
+
   @Override
   protected byte[] getATR() {
     return card.getATR();

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/AbstractExampleActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/AbstractExampleActivity.kt
@@ -26,18 +26,20 @@ import kotlinx.android.synthetic.main.activity_calypso_examples.drawerLayout
 import kotlinx.android.synthetic.main.activity_calypso_examples.eventRecyclerView
 import kotlinx.android.synthetic.main.activity_calypso_examples.navigationView
 import kotlinx.android.synthetic.main.activity_calypso_examples.toolbar
+import org.eclipse.keyple.core.card.selection.AbstractSmartCard
 import org.eclipse.keyple.core.card.selection.CardSelection
 import org.eclipse.keyple.core.service.SmartCardService
 import org.eclipse.keyple.core.service.event.ObservableReader
 import org.eclipse.keyple.core.service.event.ReaderEvent
 import org.eclipse.keyple.core.service.util.ContactlessCardCommonProtocols
+import org.eclipse.keyple.core.util.ByteArrayUtil
 import org.eclipse.keyple.example.adapter.EventAdapter
 import org.eclipse.keyple.example.calypso.android.nfc.R
 import org.eclipse.keyple.example.model.ChoiceEventModel
 import org.eclipse.keyple.example.model.EventModel
 import org.eclipse.keyple.example.util.configFlags
-import org.eclipse.keyple.example.util.configProtocol
 import org.eclipse.keyple.plugin.android.nfc.AndroidNfcPluginFactory
+import org.eclipse.keyple.plugin.android.nfc.AndroidNfcProtocolSettings
 import org.eclipse.keyple.plugin.android.nfc.AndroidNfcReader
 import timber.log.Timber
 
@@ -85,7 +87,7 @@ abstract class AbstractExampleActivity : AppCompatActivity(), NavigationView.OnN
         /**
          * Register AndroidNfc plugin Factory
          */
-        val plugin = SmartCardService.getInstance().registerPlugin(AndroidNfcPluginFactory())
+        val plugin = SmartCardService.getInstance().registerPlugin(AndroidNfcPluginFactory(this))
 
         /**
          *  remove the observer if it already exist
@@ -96,7 +98,8 @@ abstract class AbstractExampleActivity : AppCompatActivity(), NavigationView.OnN
         (reader as ObservableReader).addObserver(this)
 
         // with this protocol settings we activate the nfc for ISO1443_4 protocol
-        reader.configProtocol(ContactlessCardCommonProtocols.ISO_14443_4)
+        reader.activateProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name,
+                AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
 
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
@@ -163,4 +166,31 @@ abstract class AbstractExampleActivity : AppCompatActivity(), NavigationView.OnN
     }
 
     abstract fun initContentView()
+
+    override fun onDestroy() {
+        SmartCardService.getInstance().plugins.forEach {
+            SmartCardService.getInstance().unregisterPlugin(it.key)
+        }
+        super.onDestroy()
+    }
+
+    protected fun getSmardCardInfos(smartCard: AbstractSmartCard, index: Int): String{
+        val atr = try {
+            ByteArrayUtil.toHex(smartCard.atrBytes)
+        } catch (e: IllegalStateException) {
+            Timber.w(e)
+            e.message
+        }
+        val fci = try {
+            ByteArrayUtil.toHex(smartCard.fciBytes)
+        } catch (e: IllegalStateException) {
+            Timber.w(e)
+            e.message
+        }
+
+        return "Selection status for selection " +
+                "(indexed $index): \n\t\t" +
+                "ATR: ${atr}\n\t\t" +
+                "FCI: $fci"
+    }
 }

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
@@ -37,13 +37,14 @@ import org.eclipse.keyple.core.service.util.ContactlessCardCommonProtocols
 import org.eclipse.keyple.core.util.ByteArrayUtil
 import org.eclipse.keyple.example.calypso.android.nfc.R
 import org.eclipse.keyple.example.util.CalypsoClassicInfo
+import org.eclipse.keyple.plugin.android.nfc.AndroidNfcProtocolSettings
 import timber.log.Timber
 
 class CoreExamplesActivity : AbstractExampleActivity() {
 
     override fun onResume() {
         super.onResume()
-        reader.enableNFCReaderMode(this)
+        reader.startCardDetection(ObservableReader.PollingMode.REPEATING)
     }
 
     override fun initContentView() {
@@ -95,11 +96,12 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             cardSelection.prepareSelection(
                     GenericCardSelectionRequest(
                             CardSelector.builder()
-                                    .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
+                                    .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
                                     .aidSelector(AidSelector.builder()
                                             .aidToSelect(cardAidPrefix)
-                                            .fileOccurrence(CardSelector.AidSelector.FileOccurrence.FIRST)
-                                            .fileControlInformation(CardSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI)
+                                            .build())
                                     .build()))
 
             /* Do the selection and display the result */
@@ -119,11 +121,12 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             cardSelection.prepareSelection(
                     GenericCardSelectionRequest(
                             CardSelector.builder()
-                                    .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
-                                    .aidSelector(CardSelector.AidSelector.builder()
+                                    .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(cardAidPrefix)
-                                            .fileOccurrence(CardSelector.AidSelector.FileOccurrence.NEXT)
-                                            .fileControlInformation(CardSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI)
+                                            .build())
                                     .build()))
 
             /* Do the selection and display the result */
@@ -139,11 +142,8 @@ class CoreExamplesActivity : AbstractExampleActivity() {
         try {
             val selectionsResult = cardSelection.processExplicitSelection(reader)
             if (selectionsResult.hasActiveSelection()) {
-                    val smartCard = selectionsResult.activeSmartCard
-                    addResultEvent("Selection status for selection " +
-                            "(indexed $index): \n\t\t" +
-                            "ATR: ${ByteArrayUtil.toHex(smartCard.atrBytes)}\n\t\t" +
-                            "FCI: ${ByteArrayUtil.toHex(smartCard.fciBytes)}")
+                val smartCard = selectionsResult.activeSmartCard
+                addResultEvent(getSmardCardInfos(smartCard, index))
             } else {
                 addResultEvent("The selection did not match for case $index.")
             }
@@ -171,33 +171,36 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             cardSelection.prepareSelection(
                     GenericCardSelectionRequest(
                             CardSelector.builder()
-                                    .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
-                                    .aidSelector(CardSelector.AidSelector.builder()
+                                    .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(cardAidPrefix)
-                                            .fileOccurrence(CardSelector.AidSelector.FileOccurrence.FIRST)
-                                            .fileControlInformation(CardSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI)
+                                            .build())
                                     .build()))
 
             /* next selection (2nd selection, later indexed 1) */
             cardSelection.prepareSelection(
                     GenericCardSelectionRequest(
                             CardSelector.builder()
-                                    .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
-                                    .aidSelector(CardSelector.AidSelector.builder()
+                                    .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(cardAidPrefix)
-                                            .fileOccurrence(CardSelector.AidSelector.FileOccurrence.NEXT)
-                                            .fileControlInformation(CardSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI)
+                                            .build())
                                     .build()))
 
             /* next selection (3rd selection, later indexed 2) */
             cardSelection.prepareSelection(
                     GenericCardSelectionRequest(
                             CardSelector.builder()
-                                    .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
-                                    .aidSelector(CardSelector.AidSelector.builder()
+                                    .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(cardAidPrefix)
-                                            .fileOccurrence(CardSelector.AidSelector.FileOccurrence.NEXT)
-                                            .fileControlInformation(CardSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI)
+                                            .build())
                                     .build()))
 
             addActionEvent("Calypso PO selection for prefix: $cardAidPrefix")
@@ -208,13 +211,9 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             try {
                 val selectionResult = cardSelection.processExplicitSelection(reader)
 
-                if (selectionResult.smartCards.size > 0) {
+                if (selectionResult.smartCards.isNotEmpty()) {
                     selectionResult.smartCards.forEach {
-                        val smartCard = it.value
-                        addResultEvent("Selection status for selection " +
-                                "(indexed ${it.key}): \n\t\t" +
-                                "ATR: ${ByteArrayUtil.toHex(smartCard.atrBytes)}\n\t\t" +
-                                "FCI: ${ByteArrayUtil.toHex(smartCard.fciBytes)}")
+                        addResultEvent(getSmardCardInfos(it.value, it.key))
                     }
                     addResultEvent("End of selection")
                 } else {
@@ -253,9 +252,11 @@ class CoreExamplesActivity : AbstractExampleActivity() {
          * selection
          */
         val cardSelector = GenericCardSelectionRequest(CardSelector.builder()
-                .cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name)
-                .aidSelector(AidSelector.builder()
-                        .aidToSelect(aid).build())
+                .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                .aidSelector(
+                        AidSelector.builder()
+                                .aidToSelect(aid)
+                                .build())
                 .build())
 
         /*
@@ -296,7 +297,8 @@ class CoreExamplesActivity : AbstractExampleActivity() {
                             addResultEvent("CARD_REMOVED event: There is no PO inserted anymore. Return to the waiting state...")
                         }
 
-                        else -> { }
+                        else -> {
+                        }
                     }
                     eventRecyclerView.smoothScrollToPosition(events.size - 1)
                 }
@@ -344,9 +346,15 @@ class CoreExamplesActivity : AbstractExampleActivity() {
              * Generic selection: configures a CardSelector with all the desired attributes to make
              * the selection and read additional information afterwards
              */
+
             val genericCardSelectionRequest = GenericCardSelectionRequest(
-                    CardSelector.builder().cardProtocol(ContactlessCardCommonProtocols.ISO_14443_4.name).aidSelector(
-                            AidSelector.builder().aidToSelect(aid).build()).build())
+                    CardSelector.builder()
+                            .cardProtocol(AndroidNfcProtocolSettings.getSetting(ContactlessCardCommonProtocols.ISO_14443_4.name))
+                            .aidSelector(
+                                    AidSelector.builder()
+                                            .aidToSelect(aid)
+                                            .build())
+                            .build())
 
             /**
              * Prepare Selection
@@ -398,7 +406,7 @@ class CoreExamplesActivity : AbstractExampleActivity() {
     inner class GenericCardSelectionRequest(cardSelector: CardSelector) : AbstractCardSelectionRequest<AbstractApduCommandBuilder>(cardSelector) {
         override fun parse(CardSelectionResponse: CardSelectionResponse): AbstractSmartCard {
             class GenericSmartCard(
-                CardSelectionResponse: CardSelectionResponse
+                    CardSelectionResponse: CardSelectionResponse
             ) : AbstractSmartCard(CardSelectionResponse)
             return GenericSmartCard(CardSelectionResponse)
         }

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/util/Extensions.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/util/Extensions.kt
@@ -14,7 +14,9 @@ package org.eclipse.keyple.example.util
 import android.content.Context
 import android.os.Build
 import org.eclipse.keyple.core.service.util.ContactlessCardCommonProtocols
+import org.eclipse.keyple.plugin.android.nfc.AndroidNfcProtocolSettings
 import org.eclipse.keyple.plugin.android.nfc.AndroidNfcReader
+import org.eclipse.keyple.plugin.android.nfc.AndroidNfcSupportedProtocols
 
 /**
  * Extensions to improve readability of example code
@@ -23,10 +25,6 @@ fun AndroidNfcReader.configFlags(presenceCheckDelay: Int? = null, noPlateformSou
     presenceCheckDelay?.let { this.setParameter("FLAG_READER_PRESENCE_CHECK_DELAY", "$presenceCheckDelay") }
     noPlateformSound?.let { this.setParameter("FLAG_READER_NO_PLATFORM_SOUNDS", "$noPlateformSound") }
     skipNdefCheck?.let { this.setParameter("FLAG_READER_SKIP_NDEF_CHECK", "$skipNdefCheck") }
-}
-
-fun AndroidNfcReader.configProtocol(cardCommonProtocols: ContactlessCardCommonProtocols) {
-    this.activateProtocol(cardCommonProtocols.name, cardCommonProtocols.name)
 }
 
 fun Context.getColorResource(id: Int): Int {

--- a/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/ExamplesActivity.kt
+++ b/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/ExamplesActivity.kt
@@ -118,4 +118,11 @@ abstract class ExamplesActivity : BasicActivity(), NavigationView.OnNavigationIt
         }
         return true
     }
+
+    override fun onDestroy() {
+        SmartCardService.getInstance().plugins.forEach {
+            SmartCardService.getInstance().unregisterPlugin(it.key)
+        }
+        super.onDestroy()
+    }
 }


### PR DESCRIPTION
* Keyple plugin handles Android NFC enabling/disabling
+ Implements method 'onStartDetection' and 'onStopDetection' in AbstractObservableLocalReader.java

Signed-off-by: Youssef Amrani <youssef.amrani@yamapps.fr>

* Run spotlessApply + PmdRules

Signed-off-by: Youssef Amrani <youssef.amrani@yamapps.fr>

* Check Context nullity in methods 'onStartDetection' and 'onStopDetection'

Signed-off-by: Youssef Amrani <youssef.amrani@yamapps.fr>